### PR TITLE
fix: Critical bugs — reminders, OAuth flow, formatting, timezone

### DIFF
--- a/apps/gateway/src/telegram/telegram.service.ts
+++ b/apps/gateway/src/telegram/telegram.service.ts
@@ -586,17 +586,27 @@ Puedes enviarme audios y los proceso como texto.
     if (!text?.trim()) return;
 
     try {
-      // Si el mensaje es muy largo, lo dividimos
+      const sendChunk = async (chunk: string) => {
+        try {
+          // Intentar con Markdown para bold, italic, etc.
+          await this.bot.api.sendMessage(telegramId, chunk, {
+            parse_mode: "Markdown",
+          });
+        } catch {
+          // Si Markdown falla (formato inválido), enviar como texto plano
+          const plain = chunk.replace(/[*_`\[\]]/g, "");
+          await this.bot.api.sendMessage(telegramId, plain);
+        }
+      };
+
       if (text.length <= LIMITS.TELEGRAM_MAX_MESSAGE_LENGTH) {
-        await this.bot.api.sendMessage(telegramId, text);
+        await sendChunk(text);
         return;
       }
 
-      // Dividir en chunks respetando párrafos
       const chunks = this.splitMessage(text);
       for (const chunk of chunks) {
-        await this.bot.api.sendMessage(telegramId, chunk);
-        // Pequeña pausa entre mensajes para evitar rate limiting
+        await sendChunk(chunk);
         await new Promise((resolve) => setTimeout(resolve, 300));
       }
     } catch (error) {

--- a/apps/gateway/src/tools/tools.service.ts
+++ b/apps/gateway/src/tools/tools.service.ts
@@ -26,7 +26,14 @@ export class ToolsService {
     assistant: Assistant,
   ): Promise<{ tools: Record<string, Tool>; promptInstructions: string[] }> {
     const connectedProviders = await this.getConnectedProviders(user.id);
-    const ctx: SkillContext = { user, assistant, connectedProviders };
+    const ctx: SkillContext = {
+      user,
+      assistant,
+      connectedProviders,
+      services: {
+        scheduleReminder: (params) => this.schedulerService.scheduleReminder(params),
+      },
+    };
 
     const tools = skillRegistry.buildAllTools(ctx);
     const promptInstructions = skillRegistry.getPromptInstructions(ctx);

--- a/apps/gateway/src/whatsapp/whatsapp.service.ts
+++ b/apps/gateway/src/whatsapp/whatsapp.service.ts
@@ -377,6 +377,9 @@ export class WhatsAppService {
       const chunks = this.splitMessage(text);
 
       for (const chunk of chunks) {
+        // Convert Markdown to WhatsApp format
+        const formatted = this.markdownToWhatsApp(chunk);
+
         const response = await fetch(
           `${GRAPH_API_BASE}/${phoneNumberId}/messages`,
           {
@@ -389,7 +392,7 @@ export class WhatsAppService {
               messaging_product: "whatsapp",
               to,
               type: "text",
-              text: { body: chunk },
+              text: { body: formatted },
             }),
           },
         );
@@ -483,5 +486,25 @@ export class WhatsAppService {
 
     if (current) chunks.push(current.trim());
     return chunks;
+  }
+
+  // ============================================================
+  // Convert Markdown to WhatsApp formatting
+  // Markdown: **bold** _italic_ `code`
+  // WhatsApp: *bold* _italic_ ```code```
+  // ============================================================
+
+  private markdownToWhatsApp(text: string): string {
+    return text
+      // **bold** → *bold*
+      .replace(/\*\*(.+?)\*\*/g, "*$1*")
+      // __bold__ → *bold*
+      .replace(/__(.+?)__/g, "*$1*")
+      // ~~strike~~ → ~strike~
+      .replace(/~~(.+?)~~/g, "~$1~")
+      // Remove markdown headers (## Title → Title)
+      .replace(/^#{1,6}\s+/gm, "")
+      // Remove markdown links [text](url) → text (url)
+      .replace(/\[([^\]]+)\]\(([^)]+)\)/g, "$1 ($2)");
   }
 }

--- a/packages/skills/src/base-skill.ts
+++ b/packages/skills/src/base-skill.ts
@@ -6,6 +6,17 @@ export interface SkillContext {
   assistant: Assistant;
   /** OAuth providers the user has connected (checked at request time) */
   connectedProviders?: string[];
+  /** Gateway services exposed to skills */
+  services?: {
+    scheduleReminder?: (params: {
+      userId: string;
+      telegramId: number;
+      message: string;
+      assistantName: string;
+      triggerAt: Date;
+      additionalContext?: string;
+    }) => Promise<string>;
+  };
 }
 
 export interface SkillDefinition {

--- a/packages/skills/src/briefing/index.ts
+++ b/packages/skills/src/briefing/index.ts
@@ -46,7 +46,7 @@ export const briefingSkill: SkillDefinition = {
             enabled,
             time: formatted,
             message: enabled
-              ? `Resumen diario activado a las ${formatted} UTC`
+              ? `Resumen diario activado a las ${formatted} (hora del usuario)`
               : "Resumen diario desactivado",
           };
         } catch {

--- a/packages/skills/src/finance/index.ts
+++ b/packages/skills/src/finance/index.ts
@@ -157,9 +157,16 @@ export const financeSkill: SkillDefinition = {
           let creditCardId: string | undefined;
           if (payment_method === "credit" && credit_card_last_four) {
             const cards = await getUserCreditCards(ctx.user.id);
-            creditCardId = cards.find(
+            const card = cards.find(
               (c) => c.lastFourDigits === credit_card_last_four,
-            )?.id;
+            );
+            if (!card) {
+              return {
+                success: false,
+                error: `No encontre una tarjeta con terminacion ${credit_card_last_four}. Registrala primero con add_credit_card.`,
+              };
+            }
+            creditCardId = card.id;
           }
           const tx = await createTransaction({
             userId: ctx.user.id,

--- a/packages/skills/src/health/index.ts
+++ b/packages/skills/src/health/index.ts
@@ -150,7 +150,7 @@ export const healthSkill: SkillDefinition = {
               success: false,
               error: `No encontré un hábito llamado "${habit_name}"`,
             };
-          const today = new Date().toISOString().split("T")[0];
+          const today = new Date().toLocaleDateString("en-CA", { timeZone: ctx.user.timezone });
           await logHabit(habit.id, ctx.user.id, today, count);
           return {
             success: true,

--- a/packages/skills/src/registry.ts
+++ b/packages/skills/src/registry.ts
@@ -59,11 +59,18 @@ export class SkillRegistry {
     const connected = ctx.connectedProviders ?? [];
 
     for (const skill of this.getEnabled()) {
+      const skillTools = skill.buildTools(ctx);
+
       if (skill.requiresOAuth && !connected.includes(skill.requiresOAuth)) {
-        // Skip OAuth skills that aren't connected (connect_* tool handles it)
+        // OAuth not connected: only expose connect_* tools so user can initiate connection
+        for (const [name, t] of Object.entries(skillTools)) {
+          if (name.startsWith("connect_")) {
+            tools[name] = t;
+          }
+        }
         continue;
       }
-      const skillTools = skill.buildTools(ctx);
+
       Object.assign(tools, skillTools);
     }
 

--- a/packages/skills/src/reminders/index.ts
+++ b/packages/skills/src/reminders/index.ts
@@ -5,19 +5,20 @@ import type { SkillDefinition } from "../base-skill.js";
 export const remindersSkill: SkillDefinition = {
   name: "reminders",
   description:
-    "Programa recordatorios para enviar al usuario en un momento específico",
+    "Programa recordatorios para enviar al usuario en un momento especifico",
   category: "productivity",
   forProfiles: ["young", "adult", "senior"],
 
   buildTools: (ctx) => ({
     create_reminder: tool({
       description:
-        "Programa un recordatorio para enviarle un mensaje al usuario en un momento específico. " +
-        "Úsalo cuando el usuario pida que le recuerdes algo.",
+        "Programa un recordatorio para enviarle un mensaje al usuario en un momento especifico. " +
+        "Usalo cuando el usuario pida que le recuerdes algo. " +
+        "Ejemplos: 'recuerdame en 10 minutos', 'avisame manana a las 9am'.",
       parameters: z.object({
         message: z
           .string()
-          .describe("El mensaje del recordatorio que se enviará al usuario"),
+          .describe("El mensaje del recordatorio que se enviara al usuario"),
         trigger_at: z
           .string()
           .describe(
@@ -29,18 +30,61 @@ export const remindersSkill: SkillDefinition = {
           .describe("Contexto adicional para el recordatorio"),
       }),
       execute: async ({ message, trigger_at, context }) => {
-        // Reminders require the SchedulerService from the gateway.
-        // This skill currently serves as a placeholder until gateway
-        // integration passes a scheduleReminder function through the context.
-        return {
-          success: false,
-          error: "Reminders require gateway integration",
-        };
+        const scheduleReminder = ctx.services?.scheduleReminder;
+        if (!scheduleReminder) {
+          return {
+            success: false,
+            error: "El servicio de recordatorios no esta disponible",
+          };
+        }
+
+        try {
+          const triggerDate = new Date(trigger_at);
+          if (isNaN(triggerDate.getTime())) {
+            return { success: false, error: "Fecha invalida" };
+          }
+
+          if (triggerDate.getTime() <= Date.now()) {
+            return {
+              success: false,
+              error: "No se puede programar un recordatorio en el pasado",
+            };
+          }
+
+          const jobId = await scheduleReminder({
+            userId: ctx.user.id,
+            telegramId: ctx.user.telegramId,
+            message,
+            assistantName: ctx.assistant.name,
+            triggerAt: triggerDate,
+            additionalContext: context,
+          });
+
+          const formatted = triggerDate.toLocaleString("es-MX", {
+            timeZone: ctx.user.timezone,
+            weekday: "long",
+            month: "long",
+            day: "numeric",
+            hour: "2-digit",
+            minute: "2-digit",
+          });
+
+          return {
+            success: true,
+            jobId,
+            scheduledFor: formatted,
+          };
+        } catch (error) {
+          return {
+            success: false,
+            error: "No se pudo programar el recordatorio",
+          };
+        }
       },
     }),
   }),
 
   promptInstructions: [
-    "- create_reminder: Programa un recordatorio para una fecha y hora específica",
+    "- create_reminder: Programa un recordatorio para una fecha y hora especifica. Funciona con lenguaje natural.",
   ],
 };


### PR DESCRIPTION
## Summary

### Critical
- **OAuth connect tools unreachable**: `connect_google` and `connect_spotify` were skipped by the registry when the user hadn't connected yet — making it impossible to initiate OAuth. Now exposed even without connection.

### Major  
- **Reminders**: SchedulerService injected via `SkillContext.services` — fully functional again
- **Health habits**: Date logging uses user timezone instead of UTC (off-by-one day fix)
- **Finance**: Credit card lookup returns explicit error if card not found
- **Briefing**: Time label clarified

### Formatting
- **Telegram**: `parse_mode: Markdown` with plain text fallback
- **WhatsApp**: `markdownToWhatsApp()` converter for proper formatting

## Test plan
- [ ] Build + 121 tests pass
- [ ] Reminders work: 'Recuerdame en 5 minutos...'
- [ ] OAuth flow: 'Conecta mi Google' shows link for unconnected users
- [ ] Telegram bold/italic renders correctly
- [ ] WhatsApp formatting clean (no raw asterisks)