### PR TITLE
fix: Flexible onboarding + confirmation for sensitive actions

### DIFF
--- a/apps/gateway/src/conversation/onboarding.service.ts
+++ b/apps/gateway/src/conversation/onboarding.service.ts
@@ -34,18 +34,34 @@ export class OnboardingService {
     const state = await this.usersService.getOnboardingState(user.id);
     const currentStep = state?.currentStep ?? "welcome";
 
+    const input = text.trim().toLowerCase();
+    const data = state?.data ?? {};
+
+    // Allow going back at any step
+    if (
+      currentStep !== "name_selection" &&
+      (input === "volver" ||
+        input === "atras" ||
+        input === "cambiar" ||
+        input === "corregir" ||
+        input === "reiniciar" ||
+        input === "back")
+    ) {
+      return this.goBack(user, currentStep, data);
+    }
+
     switch (currentStep) {
       case "name_selection":
-        return this.handleNameSelection(user, text, state?.data ?? {});
+        return this.handleNameSelection(user, text, data);
 
       case "user_name":
-        return this.handleUserName(user, text, state?.data ?? {});
+        return this.handleUserName(user, text, data);
 
       case "age_range":
-        return this.handleAgeRange(user, text, state?.data ?? {});
+        return this.handleAgeRange(user, text, data);
 
       case "interests":
-        return this.handleInterests(user, text, state?.data ?? {});
+        return this.handleInterests(user, text, data);
 
       case "completed":
         return { message: "", isComplete: true };
@@ -290,6 +306,47 @@ export class OnboardingService {
     }
 
     return interests;
+  }
+
+  private async goBack(
+    user: User,
+    currentStep: string,
+    data: Record<string, unknown>,
+  ): Promise<OnboardingResponse> {
+    const stepMap: Record<string, string> = {
+      user_name: "name_selection",
+      age_range: "user_name",
+      interests: "age_range",
+    };
+
+    const previousStep = stepMap[currentStep];
+    if (!previousStep) {
+      return {
+        message: await this.startOnboarding(user),
+        isComplete: false,
+      };
+    }
+
+    await this.usersService.setOnboardingStep(
+      user.id,
+      previousStep as any,
+      data,
+    );
+
+    const messages: Record<string, string> = {
+      name_selection: `De acuerdo, empecemos de nuevo. ¿Como quieres que me llame?`,
+      user_name: `Claro, corrijamos. ¿Como te llamas tu?`,
+      age_range: `Sin problema. ¿En que rango de edad estas?\n\n1. Joven (18-30)\n2. Adulto (31-55)\n3. Adulto mayor (56+)`,
+    };
+
+    this.logger.log(
+      `Onboarding: user ${user.id} went back from ${currentStep} to ${previousStep}`,
+    );
+
+    return {
+      message: messages[previousStep] ?? await this.startOnboarding(user),
+      isComplete: false,
+    };
   }
 
   async needsOnboarding(userId: string): Promise<boolean> {

--- a/apps/gateway/src/oauth/oauth.controller.ts
+++ b/apps/gateway/src/oauth/oauth.controller.ts
@@ -2,10 +2,13 @@ import { Controller, Get, Query, Res, Logger } from "@nestjs/common";
 import type { Response } from "express";
 import { exchangeGoogleCode, exchangeSpotifyCode } from "@evva/ai";
 import { upsertOAuthToken } from "@evva/database";
+import { CacheService } from "../cache/cache.service.js";
 
 @Controller("oauth")
 export class OAuthController {
   private readonly logger = new Logger(OAuthController.name);
+
+  constructor(private readonly cache: CacheService) {}
 
   /**
    * Google OAuth callback.
@@ -48,6 +51,9 @@ export class OAuthController {
         scope: tokens.scope,
         expiresAt,
       });
+
+      // Invalidate provider cache so tools are available immediately
+      await this.cache.del(`user:${userId}:providers`);
 
       this.logger.log(`Google OAuth completed for user ${userId}`);
 
@@ -106,6 +112,8 @@ export class OAuthController {
         refreshToken: tokens.refreshToken,
         expiresAt,
       });
+
+      await this.cache.del(`user:${userId}:providers`);
 
       this.logger.log(`Spotify OAuth completed for user ${userId}`);
 

--- a/packages/ai/src/prompts/builder.ts
+++ b/packages/ai/src/prompts/builder.ts
@@ -64,8 +64,17 @@ export function buildSystemPrompt(input: SystemPromptInput): string {
 Comportamiento proactivo:
 - Guarda facts automaticamente cuando el usuario mencione datos personales relevantes.
 - Guarda contactos cuando mencionen nombre + telefono/email.
-- Al leer correos, propón acciones concretas (recordatorios, notas, citas).
-- Acepta notas de voz y fotos.`);
+- Al leer correos, propon acciones concretas (recordatorios, notas, citas).
+- Acepta notas de voz y fotos.
+
+REGLA CRITICA — Confirmacion antes de acciones sensibles:
+SIEMPRE muestra un resumen y pide confirmacion ANTES de ejecutar estas acciones:
+- Enviar correos (send_email): muestra destinatario, asunto y cuerpo, pregunta "¿Lo envio?"
+- Registrar transacciones financieras (record_transaction): muestra monto, descripcion y metodo, pregunta "¿Lo registro?"
+- Crear eventos de calendario (create_calendar_event): muestra titulo, fecha y hora, pregunta "¿Lo agendo?"
+- Eliminar notas, contactos o datos (delete/archive): pregunta "¿Seguro que quieres eliminarlo?"
+Solo ejecuta la tool cuando el usuario confirme explicitamente (si, dale, envialo, ok, etc.).
+Para acciones no sensibles (guardar facts, buscar, consultar, crear notas) puedes ejecutar directamente.`);
 
   return sections.join("\n");
 }

--- a/packages/core/src/constants/index.ts
+++ b/packages/core/src/constants/index.ts
@@ -51,10 +51,10 @@ export const ONBOARDING_MESSAGES = {
     `Hola ${firstName}, soy tu nuevo asistente personal. Voy a hacerte unas preguntas rápidas para conocerte mejor.\n\nPrimero, ¿cómo quieres que me llame?`,
 
   ASK_USER_NAME: (assistantName: string) =>
-    `Perfecto, seré ${assistantName}. ¿Y cómo te llamas tú? (tu nombre real, para dirigirme a ti)`,
+    `Perfecto, seré ${assistantName}. ¿Y cómo te llamas tú? (tu nombre real, para dirigirme a ti)\n\n(Escribe "volver" si quieres cambiar mi nombre)`,
 
   ASK_AGE_RANGE: (userName: string) =>
-    `Mucho gusto, ${userName}. Para mostrarte las funciones más útiles, ¿en qué rango de edad estás?\n\n1. Joven (18-30)\n2. Adulto (31-55)\n3. Adulto mayor (56+)\n\nResponde con el número o la palabra.`,
+    `Mucho gusto, ${userName}. Para mostrarte las funciones más útiles, ¿en qué rango de edad estás?\n\n1. Joven (18-30)\n2. Adulto (31-55)\n3. Adulto mayor (56+)\n\nResponde con el número. Escribe "volver" para corregir tu nombre.`,
 
   ASK_INTERESTS_YOUNG: (assistantName: string) =>
     `Genial. Como ${assistantName}, puedo ayudarte con muchas cosas. ¿Cuáles te interesan más?\n\n` +

--- a/packages/skills/src/calendar/index.ts
+++ b/packages/skills/src/calendar/index.ts
@@ -40,7 +40,8 @@ export const calendarSkill: SkillDefinition = {
           expiresAt,
         });
         return refreshed.accessToken;
-      } catch {
+      } catch (err) {
+        console.error(`[Calendar] Failed to refresh Google token for user ${userId}:`, err);
         return null;
       }
     };

--- a/packages/skills/src/gmail/index.ts
+++ b/packages/skills/src/gmail/index.ts
@@ -35,7 +35,8 @@ export const gmailSkill: SkillDefinition = {
           expiresAt,
         });
         return refreshed.accessToken;
-      } catch {
+      } catch (err) {
+        console.error(`[Gmail] Failed to refresh Google token for user ${userId}:`, err);
         return null;
       }
     };


### PR DESCRIPTION
## Summary

### Flexible onboarding
- User can type 'volver', 'cambiar', 'corregir', or 'back' to go to previous step
- Hints shown at each step
- Works from any step back to any previous step

### Confirmation for sensitive actions
- Claude now asks for explicit confirmation before:
  - Sending emails
  - Recording financial transactions
  - Creating calendar events
  - Deleting data
- Non-sensitive actions (save facts, search, create notes) execute directly

### Also
- OAuth token refresh logs errors (was silent catch)
- OAuth callback invalidates provider cache immediately

## Test plan
- [ ] Build + 121 tests pass
- [ ] Onboarding: type 'volver' at step 3 goes to step 2
- [ ] 'Manda un correo a X' shows draft and asks confirmation
- [ ] 'Registra un gasto de 500' shows details and asks confirmation