### PR TITLE
feat: Optional secret word for finance protection

### DIFF
--- a/packages/database/src/index.ts
+++ b/packages/database/src/index.ts
@@ -45,6 +45,9 @@ export {
   getPreferences,
   upsertPreferences,
   getUsersWithBriefingAt,
+  setFinanceSecret,
+  getFinanceSecret,
+  disableFinanceSecret,
 } from "./repositories/preferences.repository.js";
 
 export {

--- a/packages/database/src/migrations/007_finance_security.sql
+++ b/packages/database/src/migrations/007_finance_security.sql
@@ -1,0 +1,7 @@
+-- ============================================================
+-- Evva — Palabra secreta para finanzas
+-- ============================================================
+
+ALTER TABLE user_preferences
+  ADD COLUMN IF NOT EXISTS finance_secret_hash TEXT,
+  ADD COLUMN IF NOT EXISTS finance_secret_enabled BOOLEAN NOT NULL DEFAULT false;

--- a/packages/database/src/repositories/preferences.repository.ts
+++ b/packages/database/src/repositories/preferences.repository.ts
@@ -79,6 +79,43 @@ export async function getUsersWithBriefingAt(
   }));
 }
 
+export async function setFinanceSecret(
+  userId: string,
+  secretHash: string,
+): Promise<void> {
+  await query(
+    `INSERT INTO user_preferences (user_id, finance_secret_hash, finance_secret_enabled, updated_at)
+     VALUES ($1, $2, true, NOW())
+     ON CONFLICT (user_id) DO UPDATE SET
+       finance_secret_hash = $2,
+       finance_secret_enabled = true,
+       updated_at = NOW()`,
+    [userId, secretHash],
+  );
+}
+
+export async function getFinanceSecret(
+  userId: string,
+): Promise<{ hash: string; enabled: boolean } | null> {
+  const row = await queryOne(
+    "SELECT finance_secret_hash, finance_secret_enabled FROM user_preferences WHERE user_id = $1",
+    [userId],
+  );
+  if (!row || !row.finance_secret_hash) return null;
+  return {
+    hash: row.finance_secret_hash as string,
+    enabled: row.finance_secret_enabled as boolean,
+  };
+}
+
+export async function disableFinanceSecret(userId: string): Promise<void> {
+  await query(
+    `UPDATE user_preferences SET finance_secret_enabled = false, finance_secret_hash = NULL, updated_at = NOW()
+     WHERE user_id = $1`,
+    [userId],
+  );
+}
+
 function mapToPreferences(data: Record<string, unknown>): UserPreferences {
   return {
     userId: data.user_id as string,

--- a/packages/skills/src/finance-security/index.ts
+++ b/packages/skills/src/finance-security/index.ts
@@ -1,0 +1,151 @@
+import { tool } from "ai";
+import { z } from "zod";
+import { createHash } from "node:crypto";
+import type { SkillDefinition } from "../base-skill.js";
+import { setFinanceSecret, getFinanceSecret, disableFinanceSecret } from "@evva/database";
+
+function hashSecret(secret: string): string {
+  return createHash("sha256").update(secret.trim().toLowerCase()).digest("hex");
+}
+
+export const financeSecuritySkill: SkillDefinition = {
+  name: "finance-security",
+  description: "Palabra secreta opcional para proteger operaciones financieras",
+  category: "finance",
+  forProfiles: ["young", "adult", "senior"],
+
+  buildTools: (ctx) => ({
+    set_finance_secret: tool({
+      description:
+        "Configura una palabra secreta para proteger las finanzas del usuario. " +
+        "Usalo cuando el usuario quiera activar proteccion en sus datos financieros. " +
+        "La palabra secreta se pedira antes de mostrar saldos, tarjetas, transacciones o metas de ahorro.",
+      parameters: z.object({
+        secret_word: z
+          .string()
+          .min(3)
+          .describe("La palabra secreta elegida por el usuario"),
+      }),
+      execute: async ({ secret_word }) => {
+        try {
+          const hash = hashSecret(secret_word);
+          await setFinanceSecret(ctx.user.id, hash);
+          return {
+            success: true,
+            message:
+              "Palabra secreta configurada. A partir de ahora te la pedire antes de mostrar informacion financiera.",
+          };
+        } catch {
+          return {
+            success: false,
+            error: "No se pudo configurar la palabra secreta",
+          };
+        }
+      },
+    }),
+
+    verify_finance_secret: tool({
+      description:
+        "Verifica la palabra secreta del usuario para desbloquear operaciones financieras. " +
+        "SIEMPRE usa esta tool antes de ejecutar cualquier operacion financiera " +
+        "(get_credit_cards, get_finance_summary, get_recent_transactions, record_transaction, get_savings_goals) " +
+        "si el usuario tiene proteccion activada. " +
+        "Si el usuario no ha configurado palabra secreta, retorna que no es necesaria.",
+      parameters: z.object({
+        secret_word: z
+          .string()
+          .describe("La palabra secreta proporcionada por el usuario"),
+      }),
+      execute: async ({ secret_word }) => {
+        try {
+          const secret = await getFinanceSecret(ctx.user.id);
+
+          if (!secret || !secret.enabled) {
+            return {
+              success: true,
+              verified: true,
+              message: "No se requiere palabra secreta",
+            };
+          }
+
+          const inputHash = hashSecret(secret_word);
+          const verified = inputHash === secret.hash;
+
+          return {
+            success: true,
+            verified,
+            message: verified
+              ? "Palabra secreta correcta. Acceso autorizado."
+              : "Palabra secreta incorrecta. Intenta de nuevo.",
+          };
+        } catch {
+          return { success: false, error: "Error al verificar" };
+        }
+      },
+    }),
+
+    check_finance_protection: tool({
+      description:
+        "Verifica si el usuario tiene proteccion financiera activada. " +
+        "Usalo ANTES de cualquier operacion financiera para saber si necesitas pedir la palabra secreta.",
+      parameters: z.object({}),
+      execute: async () => {
+        try {
+          const secret = await getFinanceSecret(ctx.user.id);
+          return {
+            success: true,
+            protected: secret?.enabled ?? false,
+          };
+        } catch {
+          return { success: true, protected: false };
+        }
+      },
+    }),
+
+    disable_finance_secret: tool({
+      description:
+        "Desactiva la proteccion por palabra secreta de las finanzas. " +
+        "Requiere verificar la palabra secreta actual antes de desactivar.",
+      parameters: z.object({
+        current_secret: z
+          .string()
+          .describe("La palabra secreta actual para confirmar desactivacion"),
+      }),
+      execute: async ({ current_secret }) => {
+        try {
+          const secret = await getFinanceSecret(ctx.user.id);
+          if (!secret || !secret.enabled) {
+            return {
+              success: true,
+              message: "No tienes proteccion financiera activada",
+            };
+          }
+
+          const inputHash = hashSecret(current_secret);
+          if (inputHash !== secret.hash) {
+            return {
+              success: false,
+              error: "Palabra secreta incorrecta. No se puede desactivar.",
+            };
+          }
+
+          await disableFinanceSecret(ctx.user.id);
+          return {
+            success: true,
+            message: "Proteccion financiera desactivada",
+          };
+        } catch {
+          return { success: false, error: "Error al desactivar" };
+        }
+      },
+    }),
+  }),
+
+  promptInstructions: [
+    "- set_finance_secret: Configura una palabra secreta para proteger datos financieros del usuario.",
+    "- verify_finance_secret: Verifica la palabra secreta antes de mostrar datos financieros.",
+    "- check_finance_protection: Verifica si el usuario tiene proteccion financiera activada.",
+    "- disable_finance_secret: Desactiva la proteccion (requiere palabra secreta actual).",
+    "REGLA: Antes de ejecutar CUALQUIER tool financiera (get_credit_cards, get_finance_summary, record_transaction, get_recent_transactions, get_savings_goals), primero llama check_finance_protection. Si esta protegido, pide la palabra secreta al usuario y verificala con verify_finance_secret antes de proceder.",
+  ],
+};

--- a/packages/skills/src/index.ts
+++ b/packages/skills/src/index.ts
@@ -9,6 +9,7 @@ export { remindersSkill } from "./reminders/index.js";
 
 // Finance
 export { financeSkill } from "./finance/index.js";
+export { financeSecuritySkill } from "./finance-security/index.js";
 
 // Health
 export { healthSkill } from "./health/index.js";
@@ -41,6 +42,7 @@ import { notesSkill } from "./notes/index.js";
 import { contactsSkill } from "./contacts/index.js";
 import { remindersSkill } from "./reminders/index.js";
 import { financeSkill } from "./finance/index.js";
+import { financeSecuritySkill } from "./finance-security/index.js";
 import { healthSkill } from "./health/index.js";
 import { emergencySkill } from "./emergency/index.js";
 import { calendarSkill } from "./calendar/index.js";
@@ -63,6 +65,7 @@ skillRegistry.register(notesSkill);
 skillRegistry.register(contactsSkill);
 skillRegistry.register(remindersSkill);
 skillRegistry.register(financeSkill);
+skillRegistry.register(financeSecuritySkill);
 skillRegistry.register(healthSkill);
 skillRegistry.register(emergencySkill);
 skillRegistry.register(calendarSkill);


### PR DESCRIPTION
## Summary

Optional security layer for financial data. Users can set a secret word that must be provided before viewing or modifying financial information.

### Tools
- `set_finance_secret`: Set a secret word (SHA-256 hashed)
- `verify_finance_secret`: Verify before financial operations
- `check_finance_protection`: Check if protection is active
- `disable_finance_secret`: Deactivate (requires current word)

### Flow
```
User: 'Protege mis finanzas con la palabra luna'
Bot: 'Palabra secreta configurada.'

User: '¿Cuanto debo en mis tarjetas?'
Bot: 'Tus finanzas están protegidas. ¿Cuál es tu palabra secreta?'
User: 'luna'
Bot: 'Acceso autorizado. Aquí están tus tarjetas...'
```

Completely optional — if user doesn't set it, finances work normally.

## Test plan
- [ ] Build + 121 tests pass
- [ ] Set secret word works
- [ ] Financial tools ask for word when protected
- [ ] Wrong word is rejected
- [ ] Disable with correct word works